### PR TITLE
Cu 25m51q1 referrals

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -85,7 +85,7 @@ export default defineComponent({
         mdIcon: paperPlaneSharp
       },
       {
-        title: 'Referrals',
+        title: 'External Services',
         url: '/referrals',
         iosIcon: heartOutline,
         mdIcon: heartSharp

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,7 +19,9 @@
                 slot="start"
                 :icon="exitOutline"
                 :ios="exitOutline"
-                :md="exitOutline">
+                :md="exitOutline"
+                lines="none"
+                detail="false">
               </ion-icon>
               <ion-label>Sign Out</ion-label>
             </ion-item>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,6 +8,7 @@ import ReferralsPage from '@/views/Referrals.vue';
 import ResourceCenterPage from '@/views/ResourceCenter.vue';
 import DashboardPage from '@/views/Dashboard.vue';
 import HomeVisitorProfilePage from '@/views/HomeVisitorProfile.vue';
+import ExternalServiceDirectoryPage from '@/views/ExternalServiceDirectory.vue';
 import { store } from '@/store';
 
 const routes: Array<RouteRecordRaw> = [
@@ -61,7 +62,7 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     path: '/referrals',
-    component: ReferralsPage,
+    component: ExternalServiceDirectoryPage,
     meta: {
       public: false,
       onlyWhenLoggedOut: false,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,6 +9,7 @@ import ResourceCenterPage from '@/views/ResourceCenter.vue';
 import DashboardPage from '@/views/Dashboard.vue';
 import HomeVisitorProfilePage from '@/views/HomeVisitorProfile.vue';
 import ExternalServiceDirectoryPage from '@/views/ExternalServiceDirectory.vue';
+import ExternalServiceProfilePage from '@/views/ExternalServiceProfile.vue';
 import { store } from '@/store';
 
 const routes: Array<RouteRecordRaw> = [
@@ -63,6 +64,14 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: '/referrals',
     component: ExternalServiceDirectoryPage,
+    meta: {
+      public: false,
+      onlyWhenLoggedOut: false,
+    }
+  },
+  {
+    path: '/home-visitor-directory/:id',
+    component: ExternalServiceProfilePage,
     meta: {
       public: false,
       onlyWhenLoggedOut: false,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -70,7 +70,7 @@ const routes: Array<RouteRecordRaw> = [
     }
   },
   {
-    path: '/home-visitor-directory/:id',
+    path: '/referrals/:id',
     component: ExternalServiceProfilePage,
     meta: {
       public: false,

--- a/src/services/filter.service.ts
+++ b/src/services/filter.service.ts
@@ -1,0 +1,47 @@
+const FilterService = {
+    searchFilter: function (services: [], value: string, fields: string[]) {
+        if (!value) return services;
+
+        return services.filter((service: any) => {
+            for (const field of fields) {
+                if (service[field]?.toLowerCase().includes(value)) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    },
+
+    arrayValueFilter: function (services: [], field: string, value: string) {
+        if (!value) return services;
+
+        return services.filter((service: any) => {
+            return service[field].includes(value);
+        });
+    },
+
+    stringValueFilter: function (services: [], field: string, value: string) {
+        if (!value) return services;
+
+        return services.filter((service: any) => {
+            return service[field] == value;
+        });
+    },
+
+    pushArrayValueIfNotExisting: function (hayStack: string[], needleStack: string) {
+        for (const needle of needleStack) {
+            if (! hayStack.includes(needle)) {
+                hayStack.push(needle);
+            }
+        }
+    },
+
+    pushStringValueIfNotExisting: function (hayStack: string[], needle: string) {
+        if (! hayStack.includes(needle)) {
+            hayStack.push(needle);
+        }
+    }
+}
+
+export default FilterService;

--- a/src/store/externalServices.store.ts
+++ b/src/store/externalServices.store.ts
@@ -1,19 +1,16 @@
-import router from "@/router";
-import { AxiosRequestConfig } from "axios";
-import ApiService from "@/services/api.service";
-import { ssrContextKey } from "vue";
+import ApiService from '@/services/api.service';
 
 const state = {
     loaded: false,
     responseCode: 0,
     responseMessage: 0,
     responseErrors: [],
-    visitors: null
+    externalService: null
 }
 
 const getters = {
-    visitors: (state: { visitors: any }) => {
-        return state.visitors;
+    externalServices: (state: { externalServices: any }) => {
+        return state.externalServices;
     },
 
     responseCode: (state: { responseCode: any }) => {
@@ -30,8 +27,8 @@ const getters = {
 }
 
 const mutations = {
-    setVisitors(state: { visitors: any }, visitors: any) {
-        state.visitors = visitors;
+    setExternalServices(state: { externalServices: any }, externalServices: any) {
+        state.externalServices = externalServices;
     },
 
     setLoaded() {
@@ -40,16 +37,16 @@ const mutations = {
 }
 
 const actions = {
-    async fetchVisitors(context: any) {
+    async fetchExternalServices(context: any) {
         return new Promise((resolve, reject) => {
-            ApiService.get('api/visitors').then(function(response) {
+            ApiService.get('api/external-services').then(function(response) {
                 if (response && response.data && response.data.data) {
-                    const visitors = response.data.data;
+                    const externalServices = response.data.data;
 
-                    context.commit("setVisitors", visitors);
+                    context.commit("setExternalServices", externalServices);
                     context.commit("setLoaded");
 
-                    resolve(visitors);
+                    resolve(externalServices);
                 }
             })
                 .catch(error => {
@@ -59,7 +56,7 @@ const actions = {
     },
 }
 
-export const visitors = {
+export const externalServices = {
     namespaced: true, 
     state,
     getters,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import { createStore } from 'vuex';
 import { auth } from "./auth.store";
 import { announcements } from "./announcements.store";
 import { visitors } from "./visitors.store";
+import { externalServices } from './externalServices.store';
 
 export const store = createStore({
     state: {
@@ -24,6 +25,7 @@ export const store = createStore({
     modules: {
         auth,
         announcements,
-        visitors
+        visitors,
+        externalServices
     },
 })

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -76,61 +76,11 @@
                 ];
 
                 filteredServices = FilterService.searchFilter(filteredServices, searchQuery.value, fields);
-                filteredServices = stringValueFilter(filteredServices, 'benchmark', benchmarkSelect.value);
-                filteredServices = stringValueFilter(filteredServices, 'construct', constructSelect.value);
-                filteredServices = arrayValueFilter(filteredServices, 'tags', tagSelect.value);
+                filteredServices = FilterService.stringValueFilter(filteredServices, 'benchmark', benchmarkSelect.value);
+                filteredServices = FilterService.stringValueFilter(filteredServices, 'construct', constructSelect.value);
+                filteredServices = FilterService.arrayValueFilter(filteredServices, 'tags', tagSelect.value);
 
                 return filteredServices;
-            }
-
-            const searchFilter = (services: [], value: string) => {
-                if (!value) return services;
-
-                const fields = [
-                    'name',
-                    'description',
-                    'contact_1'
-                ];
-
-                return services.filter((service: any) => {
-                    for (const field of fields) {
-                        if (service[field]?.toLowerCase().includes(value)) {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                });
-            }
-
-            const arrayValueFilter = (services: [], field: string, value: string) => {
-                if (!value) return services;
-
-                return services.filter((service: any) => {
-                    return service[field].includes(value);
-                });
-            }
-
-            const stringValueFilter = (services: [], field: string, value: string) => {
-                if (!value) return services;
-
-                return services.filter((service: any) => {
-                    return service[field] == value;
-                });
-            }
-
-            const pushArrayValueIfNotExisting = (hayStack: string[], needleStack: string) => {
-                for (let needle of needleStack) {
-                    if (! hayStack.includes(needle)) {
-                        hayStack.push(needle);
-                    }
-                }
-            }
-
-            const pushStringValueIfNotExisting = (hayStack: string[], needle: string) => {
-                if (! hayStack.includes(needle)) {
-                    hayStack.push(needle);
-                }
             }
 
             return {

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -3,17 +3,50 @@
         <ion-header>
             <ion-toolbar>
                 <ion-title>
-                    Referrals Index 
+                    External Services Index 
                 </ion-title>
             </ion-toolbar>
         </ion-header>
         <ion-content>
             <ion-list>
-                <ion-item>
-                    <ion-label>Search</ion-label>
-                    <ion-input v-model="searchQuery"
-                                placeholder="Search Referrals"></ion-input>
-                </ion-item>
+                    <ion-grid>
+                        <ion-row>
+                            <ion-select v-model="benchmarkSelect" placeholder="Benchmark">
+                                <ion-select-option value="">
+                                    All Benchmarks
+                                </ion-select-option>
+                                <ion-select-option v-for="benchmark in selectOptions.benchmarks"
+                                                   :key="benchmark"
+                                                   :value="benchmark">{{ benchmark }}</ion-select-option>
+                            </ion-select>
+                            <ion-select v-model="constructSelect" placeholder="Construct">
+                                <ion-select-option v-for="construct in selectOptions.constructs"
+                                                   :key="construct"
+                                                   :value="construct">{{ construct }}</ion-select-option>
+                                <ion-select-option value="">
+                                    All Constructs
+                                </ion-select-option>
+                            </ion-select>
+                            <ion-select v-model="tagSelect" placeholder="Tag">
+                                <ion-select-option value="">
+                                    All Tags
+                                </ion-select-option>
+                                <ion-select-option v-for="tag in selectOptions.tags"
+                                                   :key="tag"
+                                                   :value="tag">{{ tag }}</ion-select-option>
+                            </ion-select>
+                        </ion-row>
+                        <ion-row>
+                            <ion-item>
+                                <ion-label>Search</ion-label>
+                                <ion-input v-model="searchQuery"
+                                            placeholder="Search Services"></ion-input>
+                                <ion-button @click="clearFilters">
+                                    Clear Filters
+                                </ion-button>
+                            </ion-item>
+                        </ion-row>
+                    </ion-grid>
                 <ion-item v-for="service in services" :key="service.id" button @click="openServiceProfile(service.id)">
                     <ion-label>
                         <h2>
@@ -36,7 +69,7 @@
     import { mapActions, mapGetters, useStore } from "vuex"
     import { useRouter } from 'vue-router';
     import { ref } from 'vue';
-    import { IonInput, IonContent, IonList, IonItem, IonLabel, IonHeader, IonTitle, IonToolbar, IonPage } from '@ionic/vue'
+    import { IonButton, IonSelect, IonSelectOption, IonGrid, IonRow, IonInput, IonContent, IonList, IonItem, IonLabel, IonHeader, IonTitle, IonToolbar, IonPage } from '@ionic/vue'
     import { computed } from "@vue/reactivity";
     import { visitors } from "@/store/visitors.store";
     import FilterService from '@/services/filter.service'; 
@@ -44,6 +77,11 @@
     export default {
         name: 'ExternalServicesDirectoryPage',
         components: {
+            IonButton,
+            IonSelect,
+            IonSelectOption,
+            IonGrid,
+            IonRow,
             IonInput,
             IonContent,
             IonList,
@@ -83,11 +121,48 @@
                 return filteredServices;
             }
 
+            const generateSelectOptions = () => {
+                let selectOptions = {
+                    benchmarks: [],
+                    constructs: [],
+                    tags: [],
+                }
+
+                let services = store.state.externalServices.externalServices;
+
+                if (!services) return selectOptions;
+
+                for (const service of services) {
+                    FilterService.pushStringValueIfNotExisting(selectOptions.benchmarks, service.benchmark);
+                    FilterService.pushStringValueIfNotExisting(selectOptions.constructs, service.construct);
+                    FilterService.pushArrayValueIfNotExisting(selectOptions.tags, service.tags);
+                }
+
+                return selectOptions;
+            }
+
+            const clearFilters = () => {
+                searchQuery.value = '';
+                benchmarkSelect.value = '';
+                constructSelect.value = '';
+                tagSelect.value = '';
+            }
+
             return {
                 services: computed(() => {
                     return filterServices();
                 }),
-                searchQuery
+
+                selectOptions: computed(() => {
+                    return generateSelectOptions();
+                }),
+
+                clearFilters,
+
+                searchQuery,
+                benchmarkSelect,
+                constructSelect,
+                tagSelect
             }
         }
     }

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -1,0 +1,110 @@
+<template>
+    <ion-page>
+        <ion-header>
+            <ion-toolbar>
+                <ion-title>
+                    Referrals Index 
+                </ion-title>
+            </ion-toolbar>
+        </ion-header>
+        <ion-content>
+            <ion-list>
+                <ion-item>
+                    <ion-label>Search</ion-label>
+                    <ion-input v-model="searchQuery"
+                                placeholder="Search Referrals"></ion-input>
+                </ion-item>
+                <ion-item v-for="service in services" :key="service.id" button @click="openServiceProfile(service.id)">
+                    <ion-label>
+                        <h2>
+                            {{ service.name }}
+                        </h2>
+                        <p> 
+                            Contact: {{ service.contact_1 }} 
+                        </p>
+                    </ion-label>
+                    <p>
+                        {{ service.description }}
+                    </p>
+                </ion-item>
+            </ion-list>
+        </ion-content>
+    </ion-page>
+</template>
+
+<script lang="ts">
+    import { mapActions, mapGetters, useStore } from "vuex"
+    import { useRouter } from 'vue-router';
+    import { ref } from 'vue';
+    import { IonInput, IonContent, IonList, IonItem, IonLabel, IonHeader, IonTitle, IonToolbar, IonPage } from '@ionic/vue'
+    import { computed } from "@vue/reactivity";
+
+    export default {
+        name: 'ExternalServicesDirectoryPage',
+        components: {
+            IonInput,
+            IonContent,
+            IonList,
+            IonLabel,
+            IonItem,
+            IonHeader,
+            IonTitle,
+            IonToolbar,
+            IonPage
+        },
+        setup() {
+            const store = useStore();
+
+            const router = useRouter();
+
+            store.dispatch('externalServices/fetchExternalServices');
+
+            let searchQuery = ref('');
+
+            const filterServices = () => {
+                let filteredServices = store.state.externalServices.externalServices;
+
+                if (!searchQuery.value) return filteredServices;
+
+                const fields = [
+                    'name',
+                    'description',
+                    'contact_1'
+                ];
+
+                filteredServices = filteredServices.filter((service: any) => {
+                    for (const field of fields) {
+                        if (service[field]?.toLowerCase().includes(searchQuery.value)) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                });
+
+                return filteredServices;
+            }
+
+            const pushArrayValueIfNotExisting = (hayStack: string[], needleStack: string) => {
+                for (let needle of needleStack) {
+                    if (! hayStack.includes(needle)) {
+                        hayStack.push(needle);
+                    }
+                }
+            }
+
+            const pushStringValueIfNotExisting = (hayStack: string[], needle: string) => {
+                if (! hayStack.includes(needle)) {
+                    hayStack.push(needle);
+                }
+            }
+
+            return {
+                services: computed(() => {
+                    return filterServices();
+                }),
+                searchQuery
+            }
+        }
+    }
+</script>

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -47,15 +47,26 @@
                             </ion-item>
                         </ion-row>
                     </ion-grid>
-                <ion-item v-for="service in services" :key="service.id" button @click="openServiceProfile(service.id)">
-                    <ion-label>
-                        <h2>
+                <ion-item v-for="service in services" 
+                          :key="service.id" 
+                          button 
+                          @click="openServiceProfile(service.id)">
+                    <ion-label class="ion-text-wrap">
+                        <h2 class="ion-text-wrap">
                             {{ service.name }}
                         </h2>
                         <p> 
                             Contact: {{ service.contact_1 }} 
                         </p>
                     </ion-label>
+                    <ion-label slot="end">
+                        <div>
+                            <ion-button v-for="tag of service.tags" :key="tag">
+                                {{ tag }}
+                            </ion-button>
+                        </div>
+                    </ion-label>
+
                 </ion-item>
             </ion-list>
         </ion-content>

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -56,9 +56,6 @@
                             Contact: {{ service.contact_1 }} 
                         </p>
                     </ion-label>
-                    <p>
-                        {{ service.description }}
-                    </p>
                 </ion-item>
             </ion-list>
         </ion-content>

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -158,7 +158,7 @@
                 }),
 
                 openServiceProfile: (id: string) => {
-                    router.push('/home-visitor-directory/' + id);
+                    router.push('/referrals/' + id);
                 },
 
                 clearFilters,

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -38,7 +38,8 @@
     import { ref } from 'vue';
     import { IonInput, IonContent, IonList, IonItem, IonLabel, IonHeader, IonTitle, IonToolbar, IonPage } from '@ionic/vue'
     import { computed } from "@vue/reactivity";
-import { visitors } from "@/store/visitors.store";
+    import { visitors } from "@/store/visitors.store";
+    import FilterService from '@/services/filter.service'; 
 
     export default {
         name: 'ExternalServicesDirectoryPage',
@@ -74,7 +75,7 @@ import { visitors } from "@/store/visitors.store";
                     'contact_1'
                 ];
 
-                filteredServices = searchFilter(filteredServices, searchQuery.value);
+                filteredServices = FilterService.searchFilter(filteredServices, searchQuery.value, fields);
                 filteredServices = stringValueFilter(filteredServices, 'benchmark', benchmarkSelect.value);
                 filteredServices = stringValueFilter(filteredServices, 'construct', constructSelect.value);
                 filteredServices = arrayValueFilter(filteredServices, 'tags', tagSelect.value);

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -38,6 +38,7 @@
     import { ref } from 'vue';
     import { IonInput, IonContent, IonList, IonItem, IonLabel, IonHeader, IonTitle, IonToolbar, IonPage } from '@ionic/vue'
     import { computed } from "@vue/reactivity";
+import { visitors } from "@/store/visitors.store";
 
     export default {
         name: 'ExternalServicesDirectoryPage',
@@ -60,11 +61,12 @@
             store.dispatch('externalServices/fetchExternalServices');
 
             let searchQuery = ref('');
+            let benchmarkSelect = ref('');
+            let constructSelect = ref('');
+            let tagSelect = ref('');
 
             const filterServices = () => {
                 let filteredServices = store.state.externalServices.externalServices;
-
-                if (!searchQuery.value) return filteredServices;
 
                 const fields = [
                     'name',
@@ -72,17 +74,48 @@
                     'contact_1'
                 ];
 
-                filteredServices = filteredServices.filter((service: any) => {
+                filteredServices = searchFilter(filteredServices, searchQuery.value);
+                filteredServices = stringValueFilter(filteredServices, 'benchmark', benchmarkSelect.value);
+                filteredServices = stringValueFilter(filteredServices, 'construct', constructSelect.value);
+                filteredServices = arrayValueFilter(filteredServices, 'tags', tagSelect.value);
+
+                return filteredServices;
+            }
+
+            const searchFilter = (services: [], value: string) => {
+                if (!value) return services;
+
+                const fields = [
+                    'name',
+                    'description',
+                    'contact_1'
+                ];
+
+                return services.filter((service: any) => {
                     for (const field of fields) {
-                        if (service[field]?.toLowerCase().includes(searchQuery.value)) {
+                        if (service[field]?.toLowerCase().includes(value)) {
                             return true;
                         }
                     }
 
                     return false;
                 });
+            }
 
-                return filteredServices;
+            const arrayValueFilter = (services: [], field: string, value: string) => {
+                if (!value) return services;
+
+                return services.filter((service: any) => {
+                    return service[field].includes(value);
+                });
+            }
+
+            const stringValueFilter = (services: [], field: string, value: string) => {
+                if (!value) return services;
+
+                return services.filter((service: any) => {
+                    return service[field] == value;
+                });
             }
 
             const pushArrayValueIfNotExisting = (hayStack: string[], needleStack: string) => {

--- a/src/views/ExternalServiceDirectory.vue
+++ b/src/views/ExternalServiceDirectory.vue
@@ -157,6 +157,10 @@
                     return generateSelectOptions();
                 }),
 
+                openServiceProfile: (id: string) => {
+                    router.push('/home-visitor-directory/' + id);
+                },
+
                 clearFilters,
 
                 searchQuery,

--- a/src/views/ExternalServiceProfile.vue
+++ b/src/views/ExternalServiceProfile.vue
@@ -1,0 +1,151 @@
+<template>
+    <ion-page>
+        <ion-header>
+            <ion-toolbar>
+                <ion-title>
+                    {{ service.name }}
+                </ion-title>
+            </ion-toolbar>
+        </ion-header>
+        <ion-content>
+            <ion-grid>
+                <ion-row class="ion-align-items-center">
+                    <ion-col size="12" size-lg="4">
+                        <p>{{ service.name }}</p>
+                        <p v-if="service.contact_1">Contact: {{ service.contact_1 }}</p>
+                        <p v-if="service.contact_2">Contact: {{ service.contact_2 }}</p>
+                    </ion-col>
+                    <ion-col size="12" size-lg="4">
+                        <h1>Description</h1>
+                        <p>{{ service.description }}</p>
+                    </ion-col>
+                    <ion-col size="0" size-lg="4"></ion-col>
+                </ion-row>
+                <ion-row>
+                    <ion-col size="0" size-xl="2"></ion-col>
+                    <ion-col size="3" size-xl="2">
+                        <ion-card>
+                            <ion-card-header>
+                                <ion-card-title>
+                                    Locations Served
+                                </ion-card-title>
+                                <ion-card-subtitle>
+                                </ion-card-subtitle>
+                            </ion-card-header>
+                            <ion-card-content>
+                                <p v-for="location in visitor.locations" :key="location">
+                                    {{ location }}
+                                </p>
+                            </ion-card-content>
+                        </ion-card>
+                    </ion-col>
+                    <ion-col size="3" size-xl="2">
+                        <ion-card>
+                            <ion-card-header>
+                                <ion-card-title>
+                                    Counties Served
+                                </ion-card-title>
+                                <ion-card-subtitle>
+                                </ion-card-subtitle>
+                            </ion-card-header>
+                            <ion-card-content>
+                                <p v-for="county in visitor.counties" :key="county">
+                                    {{ county }}
+                                </p>
+                            </ion-card-content>
+                        </ion-card>
+                    </ion-col>
+                    <ion-col size="3" size-xl="2">
+                        <ion-card>
+                            <ion-card-header>
+                                <ion-card-title>
+                                    Skills
+                                </ion-card-title>
+                                <ion-card-subtitle>
+                                </ion-card-subtitle>
+                            </ion-card-header>
+                            <ion-card-content>
+                                <p v-for="skill in visitor.skills" :key="skill">
+                                    {{ skill }}
+                                </p>
+                            </ion-card-content>
+                        </ion-card>
+                    </ion-col>
+                    <ion-col size="0" size-xl="4"></ion-col>
+                </ion-row>
+                <ion-row>
+                    <ion-col size="0" size-xl="2"></ion-col>
+                    <ion-col size="3" size-xl="2">
+                        <ion-card>
+                            <ion-card-header>
+                                <ion-card-title>
+                                    Certifications
+                                </ion-card-title>
+                                <ion-card-subtitle>
+                                </ion-card-subtitle>
+                            </ion-card-header>
+                            <ion-card-content>
+                                <p v-for="certification in visitor.certifications" :key="certification">
+                                    {{ certification }}
+                                </p>
+                            </ion-card-content>
+                        </ion-card>
+                    </ion-col>
+                    <ion-col size="3" size-xl="2">
+                        <ion-card>
+                            <ion-card-header>
+                                <ion-card-title>
+                                    Languages
+                                </ion-card-title>
+                                <ion-card-subtitle>
+                                </ion-card-subtitle>
+                            </ion-card-header>
+                            <ion-card-content>
+                                <p v-for="language in visitor.languages" :key="language">
+                                    {{ language }}
+                                </p>
+                            </ion-card-content>
+                        </ion-card>
+                    </ion-col>
+                    <ion-col size="0" size-xl="4"></ion-col>
+                </ion-row>
+            </ion-grid>
+        </ion-content>
+    </ion-page>
+</template>
+
+<script lang="ts">
+    import { store } from '@/store';
+    import { useRoute } from 'vue-router';
+    import { IonCard, IonCardHeader, IonCardSubtitle, IonCardTitle, IonCardContent, IonRow, IonCol, IonGrid, IonContent, IonPage, IonHeader, IonToolbar, IonTitle, } from '@ionic/vue';
+    import { computed } from '@vue/reactivity';
+
+    export default {
+        name: 'ExternalServiceProfilePage',
+        components: {
+            IonCard,
+            IonCardHeader,
+            IonCardSubtitle,
+            IonCardTitle,
+            IonCardContent,
+            IonRow,
+            IonCol,
+            IonContent,
+            IonGrid,
+            IonPage,
+            IonToolbar,
+            IonHeader,
+            IonTitle
+        },
+        setup() {
+            const route = useRoute();
+
+            return {
+                service: computed(() => {
+                    return store.state.externalServices.externalServices.find((x: any) => (x.id == route.params.id))
+                }),
+            }
+        }
+
+    }
+</script>

--- a/src/views/ExternalServiceProfile.vue
+++ b/src/views/ExternalServiceProfile.vue
@@ -11,103 +11,64 @@
             <ion-grid>
                 <ion-row class="ion-align-items-center">
                     <ion-col size="12" size-lg="4">
-                        <p>{{ service.name }}</p>
-                        <p v-if="service.contact_1">Contact: {{ service.contact_1 }}</p>
-                        <p v-if="service.contact_2">Contact: {{ service.contact_2 }}</p>
+                        <h4>{{ service.name }}</h4>
+                        <p v-if="service.website"><a :href="service.website">Website</a></p>
+                        <p v-if="service.phone_number">Number: {{ service.phone_number }}</p>
+                        <p v-if="service.fax_number">Fax Number: {{ service.fax_number }}</p>
+                        <p v-if="service.referral_link"><a :href="service.referral_link">Referral Link</a></p>
+                        <p v-if="service.referral_email_1">
+                            <a :href="'mailto:'+service.referral_email_1">{{ service.referral_email_1 }}</a>
+                        </p>
+                        <p v-if="service.referral_email_2">
+                            <a :href="'mailto:'+service.referral_email_2">{{ service.referral_email_2 }}</a>
+                        </p>
+                        <br>
+                        <h4 v-if="service.contact_1">Contact: {{ service.contact_1 }}</h4>
+                        <p v-if="service.contact_1_title">{{ service.contact_1_title }}</p>
+                        <p v-if="service.contact_1_phone">Phone: {{ service.contact_1_phone }}</p>
+                        <p v-if="service.contact_1_email">
+                            Email: <a :href="'mailto:'+service.contact_1_email">{{ service.contact_1_email }}</a>
+                        </p>
+                        <br>
+                        <h4 v-if="service.contact_2">Contact: {{ service.contact_2 }}</h4>
+                        <p v-if="service.contact_2_title">{{ service.contact_2_title }}</p>
+                        <p v-if="service.contact_2_phone">Phone: {{ service.contact_2_phone }}</p>
+                        <p v-if="service.contact_2_email">
+                            Email: <a :href="'mailto:'+service.contact_2_email">{{ service.contact_2_email }}</a>
+                        </p>
+                        <br>
+                        <p v-if="service.address">{{ service.address }}</p>
                     </ion-col>
                     <ion-col size="12" size-lg="4">
-                        <h1>Description</h1>
-                        <p>{{ service.description }}</p>
+                        <div v-if="service.description">
+                            <h1>Description</h1>
+                            <p>{{ service.description }}</p>
+                            <br>
+                        </div>
+                        <div v-if="service.benchmark">
+                            <h4>Benchmark</h4>
+                            <p>{{ service.benchmark }}</p>
+                            <br>
+                        </div>
+                        <div v-if="service.child_age">
+                            <p>Child Age: {{ service.child_age }}</p>
+                            <br>
+                        </div>
+                        <div v-if="service.construct">
+                            <h4>Construct</h4>
+                            <p>{{ service.construct }}</p>
+                        </div>
+                        <br>
+                        <span v-if="service.tags">
+                            <!-- !!! change switch out ion-button for analog once tailwind is brought in -->
+                            <ion-button v-for="tag of service.tags"
+                                        :key="tag"
+                                        >
+                                {{ tag }}
+                            </ion-button>
+                        </span>
                     </ion-col>
                     <ion-col size="0" size-lg="4"></ion-col>
-                </ion-row>
-                <ion-row>
-                    <ion-col size="0" size-xl="2"></ion-col>
-                    <ion-col size="3" size-xl="2">
-                        <ion-card>
-                            <ion-card-header>
-                                <ion-card-title>
-                                    Locations Served
-                                </ion-card-title>
-                                <ion-card-subtitle>
-                                </ion-card-subtitle>
-                            </ion-card-header>
-                            <ion-card-content>
-                                <p v-for="location in visitor.locations" :key="location">
-                                    {{ location }}
-                                </p>
-                            </ion-card-content>
-                        </ion-card>
-                    </ion-col>
-                    <ion-col size="3" size-xl="2">
-                        <ion-card>
-                            <ion-card-header>
-                                <ion-card-title>
-                                    Counties Served
-                                </ion-card-title>
-                                <ion-card-subtitle>
-                                </ion-card-subtitle>
-                            </ion-card-header>
-                            <ion-card-content>
-                                <p v-for="county in visitor.counties" :key="county">
-                                    {{ county }}
-                                </p>
-                            </ion-card-content>
-                        </ion-card>
-                    </ion-col>
-                    <ion-col size="3" size-xl="2">
-                        <ion-card>
-                            <ion-card-header>
-                                <ion-card-title>
-                                    Skills
-                                </ion-card-title>
-                                <ion-card-subtitle>
-                                </ion-card-subtitle>
-                            </ion-card-header>
-                            <ion-card-content>
-                                <p v-for="skill in visitor.skills" :key="skill">
-                                    {{ skill }}
-                                </p>
-                            </ion-card-content>
-                        </ion-card>
-                    </ion-col>
-                    <ion-col size="0" size-xl="4"></ion-col>
-                </ion-row>
-                <ion-row>
-                    <ion-col size="0" size-xl="2"></ion-col>
-                    <ion-col size="3" size-xl="2">
-                        <ion-card>
-                            <ion-card-header>
-                                <ion-card-title>
-                                    Certifications
-                                </ion-card-title>
-                                <ion-card-subtitle>
-                                </ion-card-subtitle>
-                            </ion-card-header>
-                            <ion-card-content>
-                                <p v-for="certification in visitor.certifications" :key="certification">
-                                    {{ certification }}
-                                </p>
-                            </ion-card-content>
-                        </ion-card>
-                    </ion-col>
-                    <ion-col size="3" size-xl="2">
-                        <ion-card>
-                            <ion-card-header>
-                                <ion-card-title>
-                                    Languages
-                                </ion-card-title>
-                                <ion-card-subtitle>
-                                </ion-card-subtitle>
-                            </ion-card-header>
-                            <ion-card-content>
-                                <p v-for="language in visitor.languages" :key="language">
-                                    {{ language }}
-                                </p>
-                            </ion-card-content>
-                        </ion-card>
-                    </ion-col>
-                    <ion-col size="0" size-xl="4"></ion-col>
                 </ion-row>
             </ion-grid>
         </ion-content>
@@ -117,17 +78,13 @@
 <script lang="ts">
     import { store } from '@/store';
     import { useRoute } from 'vue-router';
-    import { IonCard, IonCardHeader, IonCardSubtitle, IonCardTitle, IonCardContent, IonRow, IonCol, IonGrid, IonContent, IonPage, IonHeader, IonToolbar, IonTitle, } from '@ionic/vue';
+    import { IonButton, IonRow, IonCol, IonGrid, IonContent, IonPage, IonHeader, IonToolbar, IonTitle, } from '@ionic/vue';
     import { computed } from '@vue/reactivity';
 
     export default {
         name: 'ExternalServiceProfilePage',
         components: {
-            IonCard,
-            IonCardHeader,
-            IonCardSubtitle,
-            IonCardTitle,
-            IonCardContent,
+            IonButton,
             IonRow,
             IonCol,
             IonContent,

--- a/src/views/HomeVisitorDirectory.vue
+++ b/src/views/HomeVisitorDirectory.vue
@@ -62,7 +62,7 @@
                     </ion-row>
                     <ion-row>
                         <ion-item>
-                            <ion-label>Search</ion-label>
+                            <ion-label>Search:</ion-label>
                             <ion-input v-model="searchQuery"
                                        placeholder="Visitor Name"></ion-input>
                             <ion-button @click="clearFilters">Clear Filters</ion-button>
@@ -93,11 +93,10 @@
 </template>
 
 <script lang="ts">
-    import { mapActions, mapGetters } from "vuex"
+    import { mapActions, mapGetters, useStore } from "vuex"
     import { useRouter } from 'vue-router';
     import { IonButton, IonInput, IonSelectOption, IonGrid, IonSelect, IonRow, IonAvatar, IonLabel, IonPage, IonHeader, IonContent, IonList, IonToolbar, IonTitle, IonItem } from '@ionic/vue';
     import { personCircleOutline } from "ionicons/icons";
-    import { useStore } from 'vuex';
     import { computed } from "@vue/reactivity";
     import { ref } from 'vue';
     import * as JsSearch from 'js-search';

--- a/src/views/HomeVisitorDirectory.vue
+++ b/src/views/HomeVisitorDirectory.vue
@@ -101,6 +101,7 @@
     import { ref } from 'vue';
     import * as JsSearch from 'js-search';
     import { tSParenthesizedType } from "@babel/types";
+    import FilterService from "@/services/filter.service";
 
     export default {
         name: 'HomeVisitorDirectoryPage',
@@ -128,20 +129,6 @@
 
             store.dispatch('visitors/fetchVisitors');
 
-            const pushArrayValueIfNotExisting = (hayStack: string[], needleStack: string) => {
-                for (let needle of needleStack) {
-                    if (! hayStack.includes(needle)) {
-                        hayStack.push(needle);
-                    }
-                }
-            }
-
-            const pushStringValueIfNotExisting = (hayStack: string[], needle: string) => {
-                if (! hayStack.includes(needle)) {
-                    hayStack.push(needle);
-                }
-            }
-
             let countySelect = ref('');
             let agencySelect = ref('');
             let supervisorSelect = ref('');
@@ -153,41 +140,17 @@
             const filterVisitors = () => {
                 let filteredVisitors = store.state.visitors.visitors;
 
-                filteredVisitors = arrayValueFilter(filteredVisitors, 'counties', countySelect.value);
-                filteredVisitors = arrayValueFilter(filteredVisitors, 'skills', skillSelect.value);
-                filteredVisitors = arrayValueFilter(filteredVisitors, 'certifications', certificationSelect.value);
-                filteredVisitors = arrayValueFilter(filteredVisitors, 'languages', languageSelect.value);
+                filteredVisitors = FilterService.arrayValueFilter(filteredVisitors, 'counties', countySelect.value);
+                filteredVisitors = FilterService.arrayValueFilter(filteredVisitors, 'skills', skillSelect.value);
+                filteredVisitors = FilterService.arrayValueFilter(filteredVisitors, 'certifications', certificationSelect.value);
+                filteredVisitors = FilterService.arrayValueFilter(filteredVisitors, 'languages', languageSelect.value);
 
-                filteredVisitors = stringValueFilter(filteredVisitors, 'program', agencySelect.value);
-                filteredVisitors = stringValueFilter(filteredVisitors, 'supervisor', supervisorSelect.value);
+                filteredVisitors = FilterService.stringValueFilter(filteredVisitors, 'program', agencySelect.value);
+                filteredVisitors = FilterService.stringValueFilter(filteredVisitors, 'supervisor', supervisorSelect.value);
 
-                filteredVisitors =  nameSearchFilter(filteredVisitors, searchQuery.value);
+                filteredVisitors =  FilterService.searchFilter(filteredVisitors, searchQuery.value, ['name']);
 
                 return filteredVisitors;
-            }
-
-            const arrayValueFilter = (visitors: [], field: string, value: string) => {
-                if (!value) return visitors;
-
-                return visitors.filter((visitor: any) => {
-                    return visitor[field].includes(value);
-                });
-            }
-
-            const stringValueFilter = (visitors: [], field: string, value: string) => {
-                if (!value) return visitors;
-
-                return visitors.filter((visitor: any) => {
-                    return visitor[field] == value;
-                });
-            }
-
-            const nameSearchFilter = (visitors: [], value: string) => {
-                if (!value) return visitors;
-
-                return visitors.filter((visitor: any) => {
-                    return visitor.name.toLowerCase().includes(value.toLowerCase());
-                });
             }
 
             const clearFilters = () => {
@@ -219,12 +182,12 @@
                 if (! visitors) return selectOptions;
 
                 for (let visitor of visitors) {
-                    pushArrayValueIfNotExisting(selectOptions.counties, visitor.counties);
-                    pushArrayValueIfNotExisting(selectOptions.languages, visitor.languages);
-                    pushStringValueIfNotExisting(selectOptions.agencies, visitor.program);
-                    pushStringValueIfNotExisting(selectOptions.supervisors, visitor.supervisor);
-                    pushArrayValueIfNotExisting(selectOptions.skills, visitor.skills);
-                    pushArrayValueIfNotExisting(selectOptions.certifications, visitor.certifications);
+                    FilterService.pushArrayValueIfNotExisting(selectOptions.counties, visitor.counties);
+                    FilterService.pushArrayValueIfNotExisting(selectOptions.languages, visitor.languages);
+                    FilterService.pushStringValueIfNotExisting(selectOptions.agencies, visitor.program);
+                    FilterService.pushStringValueIfNotExisting(selectOptions.supervisors, visitor.supervisor);
+                    FilterService.pushArrayValueIfNotExisting(selectOptions.skills, visitor.skills);
+                    FilterService.pushArrayValueIfNotExisting(selectOptions.certifications, visitor.certifications);
                 }
 
                 return selectOptions;


### PR DESCRIPTION
# Details

This PR comprises front and back end changes for the external services section of the web app. The external service page lists external services with the ability to filter by search, benchmark select, construct select, and tag select. When a user clicks on a service, the service profile page is opened with all information for that service. The same routing bug that is present for the user profile's is present here as well. If a user does not navigate from the profile directly to the directory, navigation is broken until the page is refreshed and the app reloaded. 

# Steps to test changes

1. pull down this branch in both repos
2. run 'php artisan migrate:fresh --seed" to seed tags for external resources.
3. serve front end app with "npm run serve"
4. Open front end app in browser and navigate to "External Services" page.
5. Test search and filtering
6. Click on services to view their profile pages
7. Tags are currently clickable buttons, but this will be changed once I bring in tailwind

# Issues Addressed

[25tvc5h](https://app.clickup.com/t/25tvc5h)

# Screenshots
![Screen Shot 2022-07-27 at 10 10 57 AM](https://user-images.githubusercontent.com/29612767/181296802-73adc3c8-da0d-4340-875a-08433cca7162.png)
![Screen Shot 2022-07-27 at 10 11 23 AM](https://user-images.githubusercontent.com/29612767/181296837-b325c01a-44a4-473c-8493-8ceb910c16e2.png)
